### PR TITLE
Fix menu and toolbar

### DIFF
--- a/gtk-3.0/buttons.css
+++ b/gtk-3.0/buttons.css
@@ -243,7 +243,7 @@ toolbar button:hover {
 /* --- Primary toolbar - big button bar at the top --- */
 
 toolbar.primary-toolbar button {
-	padding: 14px 12px;
+	padding: 4px;
 	border-color: transparent;
 	border-image: none 4 4 3 4 / 4 4 3 4 repeat;
 	background-image: none;

--- a/gtk-3.0/menu.css
+++ b/gtk-3.0/menu.css
@@ -9,7 +9,7 @@
 menubar {
 	border-bottom: 1px @menubar_border_bot solid;
 	margin-top: 1px;
-	padding: 0 4px;
+	padding: 0 1px;
 	-GtkWidget-window-dragging: true;
 	background-color: transparent;
 	background-image: linear-gradient(to bottom, @menubar_grad_top, @menubar_grad_bot);
@@ -17,7 +17,7 @@ menubar {
 
 menubar menuitem {
 	border: 1px transparent solid;
-	padding: 2px 6px;
+	padding: 2px 7px;
 	background-color: transparent;
 }
 


### PR DESCRIPTION
I compare the "builder" window from _gtk-demo_ and _gtk3-demo_ (from _gtk2.0-examples_ and _gtk-3-examples_ packages). It remains a height difference of 1 or 2 px. Perhaps it will break your awf windows.

![gtk2](https://user-images.githubusercontent.com/31816829/75112368-7ab98e80-5643-11ea-8f5c-8b068b5c172c.png)
![gtk3](https://user-images.githubusercontent.com/31816829/75112366-7a20f800-5643-11ea-8e30-23f0f8c625dc.png)
